### PR TITLE
[codex] expose soc-levels topic

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,7 @@ cockpit        | get milage data
 location       | get the location
 battery-status | get battery status data
 charge-mode    | get the actual chargemode (always, scheduled, delayed)
+soc-levels     | get the target state of charge
 ...            |
 
 ## Set configuration

--- a/src/ZEServices.ts
+++ b/src/ZEServices.ts
@@ -239,6 +239,16 @@ export interface BatteryStatusAttributes {
 export interface BatteryStatus extends DataContainer<BatteryStatusAttributes> { }
 //#endregion
 
+//#region SocLevels
+export interface SocLevelsAttributes {
+    socMin: number;
+    socTarget: number;
+    lastEnergyUpdateTimestamp: Date;
+}
+
+export interface SocLevels extends DataContainer<SocLevelsAttributes> { }
+//#endregion
+
 //#region Cockpit
 export interface CockpitAttributes {
     fuelAutonomy: number;
@@ -492,6 +502,16 @@ export class ZEServices {
      */
     async chargeMode(accountId: string, vin: string, country?: string): Promise<ChargeMode> {
         return this.getAttribute<ChargeMode>("charge-mode", accountId, vin, country);
+    }
+
+    /**
+     * Fetch the current state of charge levels of the requested vehicle in the requested account.
+     * @param accountId The accountId.
+     * @param vin The vehicle identifier.
+     * @param country optional country
+     */
+    async socLevels(accountId: string, vin: string, country?: string): Promise<SocLevels> {
+        return this.getJSON<SocLevels>(this.createPathSpring(accountId, vin) + "/ev/soc-levels", country);
     }
 
     /**

--- a/src/renault-ze.ts
+++ b/src/renault-ze.ts
@@ -76,6 +76,10 @@ export = function (RED: NodeAPI) {
                                         ZE.setHVACSchedule(msg.payload, account.accountId, vehicles.vin, account.country)
                                             .then((result) => node.send({ ...msg, topic: topic, payload: result }));
                                         break;
+                                    case "soc-levels":
+                                        ZE.socLevels(account.accountId, vehicles.vin, account.country)
+                                            .then((result) => node.send({ ...msg, topic: topic, payload: result }));
+                                        break;
                                     default:
                                         ZE.getAttribute(topic, account.accountId, vehicles.vin, account.country)
                                             .then((result) => node.send({ ...msg, topic: topic, payload: result }));


### PR DESCRIPTION
## Summary

Adds support for the KCM `ev/soc-levels` endpoint through a new `soc-levels` topic.

When a message is sent with `msg.topic = "soc-levels"`, the node now calls:

```text
/commerce/v1/accounts/{accountId}/kamereon/kcm/v1/vehicles/{vin}/ev/soc-levels
```

and returns the API payload containing the target state of charge data, including `socTarget`, `socMin`, and `lastEnergyUpdateTimestamp`.

## Why

Issue #223 requests exposing `socTarget` for charge logging and "charged vs. target" flows. The value is available from the Kamereon KCM API and is already known to work for vehicles such as the Renault 5 E-Tech through other Renault API clients.

## Notes

This keeps `soc-levels` as an explicit opt-in topic and does not add it to the no-topic default request set. That avoids adding another API call/message for existing flows that currently receive only `location`, `cockpit`, and `battery-status` by default.

## Validation

- `npm run build`

Closes #223